### PR TITLE
Translate XML Schema to JSON Schema

### DIFF
--- a/src/com/mcsuka/xml/json/Xml2Json.java
+++ b/src/com/mcsuka/xml/json/Xml2Json.java
@@ -158,7 +158,7 @@ public class Xml2Json {
                 case COMPLEX, MIXED, ANY -> JsonNull.INSTANCE;
                 default -> new JsonPrimitive(stringValue);
             };
-            if (jsonNode.size() == 0) {
+            if (jsonNode.isEmpty()) {
                 return value;
             } else {
                 jsonNode.add(XML_ELEMENT_CONTENT, value);

--- a/src/com/mcsuka/xml/xsd/model/SchemaNode.java
+++ b/src/com/mcsuka/xml/xsd/model/SchemaNode.java
@@ -31,6 +31,8 @@ public class SchemaNode {
         sequence, all, choice
     }
 
+    public final static int UNBOUNDED_VALUE = Integer.MAX_VALUE;
+
     private final static Map<String, String> immutableEmptyMap = Collections.emptyMap();
     
     private final String elementName;
@@ -128,7 +130,7 @@ public class SchemaNode {
         if (indicator != null) {
             return "XmlSchemaNode {" + path + "/, " + indicator + ", " + minOccurs + ".." + maxOccurs + "}";
         } else {
-            return "XmlSchemaNode {" + elementName + ", "  + path + ", " + w3cType + ", " + minOccurs + ".." + maxOccurs
+            return "XmlSchemaNode {" + path + ", " + w3cType + ", " + minOccurs + ".." + maxOccurs
                     + (customType != null ? ", TYPE:" + customType : "") + ", NS:" + namespace
                     + (qualified ? ", QUALIFIED" : ", UNQUALIFIED") + (attribute ? ", ATTR" : "") + (any ? ", ANY" : "")
                     + ", \"" + restrictionsToText() + "\""
@@ -144,7 +146,7 @@ public class SchemaNode {
     }
     
     private String dumpTree(String prefix) {
-        String childPrefix = prefix;
+        String childPrefix = prefix + "  ";
         StringBuilder sb = new StringBuilder();
         if(isIndicator()) {
             sb.append(prefix)
@@ -164,7 +166,6 @@ public class SchemaNode {
                 .append(' ').append(defaultValue == null ? "" : "defaultValue=" + defaultValue)
                 .append('\n');
         }
-        childPrefix = prefix + "  ";
         if (recursiveParent == null) {
             for (SchemaNode child: children) {
                 sb.append(child.dumpTree(childPrefix));
@@ -229,7 +230,7 @@ public class SchemaNode {
         }
     }
     
-    public SchemaNode getChild(String childName, boolean skipIndicators) {
+    public SchemaNode getChild(String childName) {
         if (recursiveParent != null) {
             return recursiveParent.getChild(childName);
         } else {
@@ -247,10 +248,6 @@ public class SchemaNode {
                 return null;
             }
         }
-    }
-
-    public SchemaNode getChild(String childName) {
-        return getChild(childName, true);
     }
 
     public String getPath() {
@@ -448,7 +445,7 @@ public class SchemaNode {
      * Convenience method to get a textual representation of the cardinality (e.g. 1, 1..n, 0..3)
      */
     public String getCardinality() {
-        String mo = (maxOccurs == Integer.MAX_VALUE ? "n" : "" + maxOccurs);
+        String mo = (maxOccurs == UNBOUNDED_VALUE ? "n" : "" + maxOccurs);
         return minOccurs + (maxOccurs > minOccurs ? ".." + mo : "");
     }
 }

--- a/src/com/mcsuka/xml/xsd/model/SchemaNode.java
+++ b/src/com/mcsuka/xml/xsd/model/SchemaNode.java
@@ -30,6 +30,8 @@ public class SchemaNode {
     public enum IndicatorType {
         sequence, all, choice
     }
+
+    private final static Map<String, String> immutableEmptyMap = Collections.emptyMap();
     
     private final String elementName;
     private final IndicatorType indicator;
@@ -126,7 +128,7 @@ public class SchemaNode {
         if (indicator != null) {
             return "XmlSchemaNode {" + path + "/, " + indicator + ", " + minOccurs + ".." + maxOccurs + "}";
         } else {
-            return "XmlSchemaNode {" + path + ", " + w3cType + ", " + minOccurs + ".." + maxOccurs
+            return "XmlSchemaNode {" + elementName + ", "  + path + ", " + w3cType + ", " + minOccurs + ".." + maxOccurs
                     + (customType != null ? ", TYPE:" + customType : "") + ", NS:" + namespace
                     + (qualified ? ", QUALIFIED" : ", UNQUALIFIED") + (attribute ? ", ATTR" : "") + (any ? ", ANY" : "")
                     + ", \"" + restrictionsToText() + "\""
@@ -417,7 +419,7 @@ public class SchemaNode {
     }
 
     public Map<String, String> getRestrictions() {
-        return restrictions;
+        return restrictions == null ? immutableEmptyMap : Collections.unmodifiableMap(restrictions);
     }
 
     public String restrictionsToText() {

--- a/src/com/mcsuka/xml/xsd/model/SchemaParser.java
+++ b/src/com/mcsuka/xml/xsd/model/SchemaParser.java
@@ -18,6 +18,8 @@ import com.mcsuka.xml.xsd.tools.XmlTools;
 
 import org.w3c.dom.Document;
 
+import static com.mcsuka.xml.xsd.model.SchemaNode.UNBOUNDED_VALUE;
+
 /**
  * The SchemaParser takes an XSD file as an input and creates a tree of SchemaNode objects.
  * XSD references are honored, includes and imports are loaded and a new SchemaParser is initialized for each import. SchemaParser
@@ -263,7 +265,7 @@ public class SchemaParser {
                         modelNode.setMixed();
                     }
                 } else if ("anyAttribute".equals(childName)) {
-                    modelNode.addChild(new SchemaNode("*", targetNamespace, attributeQualified, true, true, 0, Integer.MAX_VALUE));
+                    modelNode.addChild(new SchemaNode("*", targetNamespace, attributeQualified, true, true, 0, UNBOUNDED_VALUE));
                 }
             }
         }
@@ -364,7 +366,7 @@ public class SchemaParser {
             return 1;
         }
         if (xOccurs.equals("unbounded")) {
-            return Integer.MAX_VALUE;
+            return UNBOUNDED_VALUE;
         }
         return Integer.parseInt(xOccurs);
     }

--- a/src/com/mcsuka/xml/xsd/model/SchemaParser.java
+++ b/src/com/mcsuka/xml/xsd/model/SchemaParser.java
@@ -200,7 +200,7 @@ public class SchemaParser {
             if (attrs.containsKey("name")) {             // element definition
                 String name = attrs.get("name");
                 String fixedValue = attrs.get("fixed");
-                String defaultValue = (fixedValue == null ? attrs.get("default") : fixedValue);
+                String defaultValue = attrs.get("default");
                 String form = attrs.get("form");
                 boolean qualified = (form == null ? elementQualified || global : "qualified".equals(form));
                 SchemaNode thisModelNode = new SchemaNode(name, null, targetNamespace,
@@ -244,21 +244,9 @@ public class SchemaParser {
                 if ("restriction".equals(childName)) {
                     applyType(attrs.get("base"), modelNode);
                     ArrayList<Element> restrictionList = XmlTools.getChildElements(child);
-                    String prevNodeName = null;
                     for (Element element: restrictionList) {
                         String nodeName = element.getLocalName();
-                        if (!nodeName.equals(prevNodeName)) {
-                            if (modelNode.getRestrictions() != null) {
-                                modelNode.appendRestrictions(", ");
-                            }
-                            modelNode.appendRestrictions(nodeName + ":");
-                        } 
-                        if ("pattern".equals(nodeName) || "enumeration".equals(nodeName)) {
-                            modelNode.appendRestrictions(" '" + XmlTools.getAttribute(element, "value") + "'");
-                        } else {
-                            modelNode.appendRestrictions(XmlTools.getAttribute(element, "value"));
-                        }
-                        prevNodeName = nodeName;
+                        modelNode.appendRestrictions(nodeName, XmlTools.getAttribute(element, "value"));
                     }
                 } else if ("extension".equals(childName)) {
                     applyType(attrs.get("base"), modelNode);
@@ -313,21 +301,10 @@ public class SchemaParser {
                 String use = attrs.get("use");
                 int mio = ("required".equals(use) ? 1 : 0);
                 int mao = ("prohibited".equals(use) ? 0 : 1);
-                String defaultValue = null;
-                String fixedValue = null;
-                String restrictions = null;
-                if (attrs.containsKey("default")) {
-                    defaultValue = attrs.get("default");
-                    restrictions = "default value: " + defaultValue;
-                }
-                if (attrs.containsKey("fixed")) {
-                    defaultValue = attrs.get("fixed");
-                    fixedValue = defaultValue;
-                    restrictions = "fixed value: " + defaultValue;
-                }
+                String defaultValue = attrs.get("default");
+                String fixedValue = attrs.get("fixed");
                 SchemaNode attributeModelNode = new SchemaNode(name, null, targetNamespace, attributeQualified, true, false,
                         defaultValue, fixedValue, mio, mao);
-                attributeModelNode.setRestrictions(restrictions);
                 parentModelNode.addChild(attributeModelNode);
                 appendChildNodes(xsdNode, attributeModelNode);
             }

--- a/src/com/mcsuka/xml/xsd/model/Xsd2JsonSchema.java
+++ b/src/com/mcsuka/xml/xsd/model/Xsd2JsonSchema.java
@@ -1,0 +1,154 @@
+package com.mcsuka.xml.xsd.model;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class Xsd2JsonSchema {
+
+    private static final Logger logger = LoggerFactory.getLogger(Xsd2JsonSchema.class.getName());
+
+    static Optional<Number> parseNumber(String num, SchemaNode.DataType type) {
+        if (num == null)
+            return Optional.empty();
+        try {
+            if (type == SchemaNode.DataType.INTEGER) {
+                return Optional.of(Integer.valueOf(num));
+            } else if (type == SchemaNode.DataType.LONG) {
+                return Optional.of(Long.valueOf(num));
+            } else if (type == SchemaNode.DataType.DOUBLE) {
+                return Optional.of(Double.valueOf(num));
+            }
+        } catch (NumberFormatException nfe) {
+            logger.warn("error parsing numeric value " + num, nfe);
+        }
+        return Optional.empty();
+    }
+
+    static JsonObject newJsonObject(String name, JsonObject value) {
+        JsonObject jo = new JsonObject();
+        jo.add(name, value);
+        return jo;
+    }
+
+    static JsonObject renderLeaf(SchemaNode leaf) {
+        if (leaf.isAttribute() && leaf.getFixedValue() != null) {
+            return null;
+        }
+        SchemaNode.DataType type = leaf.getW3CType();
+        Map<String, String> restrictions = leaf.getRestrictions();
+        JsonObject prop = new JsonObject();
+        if (type == SchemaNode.DataType.BOOLEAN) {
+            prop.addProperty("type", "boolean");
+        } else if (type == SchemaNode.DataType.INTEGER || type == SchemaNode.DataType.LONG || type == SchemaNode.DataType.DOUBLE) {
+            prop.addProperty("type", type == SchemaNode.DataType.DOUBLE ? "number" : "integer");
+            parseNumber(restrictions.get("minInclusive"), type)
+                    .ifPresent(n -> prop.addProperty("minimum", n));
+            parseNumber(restrictions.get("maxInclusive"), type)
+                    .ifPresent(n -> prop.addProperty("maximum", n));
+        } else {
+            prop.addProperty("type", "string");
+            if (type == SchemaNode.DataType.DATE) {
+                prop.addProperty("format", "date");
+            } else if (type == SchemaNode.DataType.DATETIME) {
+                prop.addProperty("format", "date-time");
+            } else if (type == SchemaNode.DataType.TIME) {
+                prop.addProperty("pattern", "^\\d{2}:\\d{2}(:\\d{2})?$'");
+            } else if (restrictions != null) {
+                Optional.ofNullable(restrictions.get("pattern"))
+                        .ifPresent(p -> prop.addProperty("pattern", p));
+                Optional.ofNullable(restrictions.get("enumeration"))
+                        .ifPresent(enums -> {
+                            JsonArray enumValues = new JsonArray();
+                            Arrays.stream(enums.split("[|]")).forEach(enumValues::add);
+                            prop.add("enum", enumValues);
+                        });
+                parseNumber(restrictions.get("length"), SchemaNode.DataType.INTEGER)
+                        .ifPresent(len -> {
+                            prop.addProperty("minLength", len);
+                            prop.addProperty("maxLength", len);
+                        });
+                parseNumber(restrictions.get("minLength"), SchemaNode.DataType.INTEGER)
+                        .ifPresent(len -> prop.addProperty("minLength", len));
+                parseNumber(restrictions.get("maxLength"), SchemaNode.DataType.INTEGER)
+                        .ifPresent(len -> prop.addProperty("maxLength", len));
+            }
+        }
+
+        if (leaf.getMaxOccurs() > 1) {
+            JsonObject array = new JsonObject();
+            array.addProperty("type", "array");
+            array.add("items", prop);
+            return array;
+        } else {
+            return prop;
+        }
+    }
+
+    public static JsonObject renderSchema(SchemaNode input) {
+
+        System.out.println(input);
+
+        if (input.isRecursive()) {
+            return new JsonObject();
+        }
+        JsonObject schema = new JsonObject();
+        schema.addProperty("type", "object");
+
+        List<? extends SchemaNode> children = input.getChildren();
+
+        if (input.getIndicator() == SchemaNode.IndicatorType.choice) {
+            JsonArray choices = new JsonArray();
+            schema.add("oneOf", choices);
+
+            for (SchemaNode child : children) {
+                choices.add(renderSchema(child));
+            }
+
+        } else {
+            JsonObject properties = new JsonObject();
+            schema.add("properties", properties);
+
+            if (input.isSimpleType()) {   // XML element with attributes
+                JsonObject value = renderLeaf(input);
+                properties.add("content", value);
+            }
+
+            List<String> required = new ArrayList<>();
+
+            for (SchemaNode child : children) {
+                if (child.isIndicator() && child.getIndicator() != SchemaNode.IndicatorType.choice) {
+                    JsonObject childProps = renderSchema(child);
+                    Optional.ofNullable(childProps.getAsJsonObject("properties"))
+                            .ifPresent(props -> props.entrySet()
+                                    .forEach(entry -> properties.add(entry.getKey(), entry.getValue())));
+                } else {
+                    JsonObject prop = child.isLeaf() ? renderLeaf(child) : renderSchema(child);
+                    if (prop != null) {
+                        properties.add(child.getElementName(), prop);
+                        if (child.getMinOccurs() > 0) {
+                            required.add(child.getElementName());
+                        }
+                    }
+                }
+            }
+
+            if (!required.isEmpty()) {
+                JsonArray array = new JsonArray();
+                required.forEach(array::add);
+                schema.add("required", array);
+            }
+            if (input.getMaxOccurs() > 1) {
+                JsonObject array = new JsonObject();
+                array.addProperty("type", "array");
+                array.add("items", schema);
+                return array;
+            }
+        }
+        return schema;
+    }
+    
+}

--- a/src/com/mcsuka/xml/xsd/model/Xsd2JsonSchema.java
+++ b/src/com/mcsuka/xml/xsd/model/Xsd2JsonSchema.java
@@ -2,14 +2,29 @@ package com.mcsuka.xml.xsd.model;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
+import static com.mcsuka.xml.xsd.model.SchemaNode.UNBOUNDED_VALUE;
+
+/**
+ * Best-effort translation of an XML Schema to a JSON Schema.
+ * Not all XML Schema constructions can be translated into JSON Schema, e.g. JSON does not ensure sequence,
+ * cannot have repeating groups of elements or a sequence of choice (oneOf) groups.
+ */
 public class Xsd2JsonSchema {
 
     private static final Logger logger = LoggerFactory.getLogger(Xsd2JsonSchema.class.getName());
+
+    public static JsonObject translateSchema(SchemaNode input) {
+        JsonObject schema = renderElement(input);
+        schema.addProperty("$schema", "https://json-schema.org/draft/2020-12/schema");
+        schema.addProperty("$id", input.getNamespace() + "?" + input.getElementName());
+        return schema;
+    }
 
     static Optional<Number> parseNumber(String num, SchemaNode.DataType type) {
         if (num == null)
@@ -28,127 +43,201 @@ public class Xsd2JsonSchema {
         return Optional.empty();
     }
 
-    static JsonObject newJsonObject(String name, JsonObject value) {
-        JsonObject jo = new JsonObject();
-        jo.add(name, value);
-        return jo;
-    }
-
+    @NotNull
     static JsonObject renderLeaf(SchemaNode leaf) {
-        if (leaf.isAttribute() && leaf.getFixedValue() != null) {
-            return null;
-        }
         SchemaNode.DataType type = leaf.getW3CType();
         Map<String, String> restrictions = leaf.getRestrictions();
-        JsonObject prop = new JsonObject();
+        JsonObject typeDef = new JsonObject();
         if (type == SchemaNode.DataType.BOOLEAN) {
-            prop.addProperty("type", "boolean");
+            typeDef.addProperty("type", "boolean");
         } else if (type == SchemaNode.DataType.INTEGER || type == SchemaNode.DataType.LONG || type == SchemaNode.DataType.DOUBLE) {
-            prop.addProperty("type", type == SchemaNode.DataType.DOUBLE ? "number" : "integer");
+            typeDef.addProperty("type", type == SchemaNode.DataType.DOUBLE ? "number" : "integer");
             parseNumber(restrictions.get("minInclusive"), type)
-                    .ifPresent(n -> prop.addProperty("minimum", n));
+                    .ifPresent(n -> typeDef.addProperty("minimum", n));
             parseNumber(restrictions.get("maxInclusive"), type)
-                    .ifPresent(n -> prop.addProperty("maximum", n));
+                    .ifPresent(n -> typeDef.addProperty("maximum", n));
         } else {
-            prop.addProperty("type", "string");
+            typeDef.addProperty("type", "string");
             if (type == SchemaNode.DataType.DATE) {
-                prop.addProperty("format", "date");
+                typeDef.addProperty("format", "date");
             } else if (type == SchemaNode.DataType.DATETIME) {
-                prop.addProperty("format", "date-time");
+                typeDef.addProperty("format", "date-time");
             } else if (type == SchemaNode.DataType.TIME) {
-                prop.addProperty("pattern", "^\\d{2}:\\d{2}(:\\d{2})?$'");
+                typeDef.addProperty("pattern", "^\\d{2}:\\d{2}(:\\d{2})?$'");
             } else if (restrictions != null) {
                 Optional.ofNullable(restrictions.get("pattern"))
-                        .ifPresent(p -> prop.addProperty("pattern", p));
+                        .ifPresent(p -> typeDef.addProperty("pattern", p));
                 Optional.ofNullable(restrictions.get("enumeration"))
                         .ifPresent(enums -> {
                             JsonArray enumValues = new JsonArray();
                             Arrays.stream(enums.split("[|]")).forEach(enumValues::add);
-                            prop.add("enum", enumValues);
+                            typeDef.add("enum", enumValues);
                         });
                 parseNumber(restrictions.get("length"), SchemaNode.DataType.INTEGER)
                         .ifPresent(len -> {
-                            prop.addProperty("minLength", len);
-                            prop.addProperty("maxLength", len);
+                            typeDef.addProperty("minLength", len);
+                            typeDef.addProperty("maxLength", len);
                         });
                 parseNumber(restrictions.get("minLength"), SchemaNode.DataType.INTEGER)
-                        .ifPresent(len -> prop.addProperty("minLength", len));
+                        .ifPresent(len -> typeDef.addProperty("minLength", len));
                 parseNumber(restrictions.get("maxLength"), SchemaNode.DataType.INTEGER)
-                        .ifPresent(len -> prop.addProperty("maxLength", len));
+                        .ifPresent(len -> typeDef.addProperty("maxLength", len));
             }
         }
 
+        if (leaf.getFixedValue() != null) {
+            typeDef.addProperty("const", leaf.getFixedValue());
+        }
+
+        if (leaf.getDefaultValue() != null) {
+            typeDef.addProperty("default", leaf.getDefaultValue());
+        }
+
         if (leaf.getMaxOccurs() > 1) {
-            JsonObject array = new JsonObject();
-            array.addProperty("type", "array");
-            array.add("items", prop);
-            return array;
+            return asArray(leaf, typeDef);
         } else {
-            return prop;
+            return typeDef;
         }
     }
 
-    public static JsonObject renderSchema(SchemaNode input) {
+    @NotNull
+    static JsonArray renderOneOf(SchemaNode input) {
+        JsonArray choices = new JsonArray();
+        List<? extends SchemaNode> children = input.getChildren();
 
-        System.out.println(input);
+        for (SchemaNode child : children) {
+            choices.add(child.isIndicator() ? renderSequence(child) : renderElement(child));
+        }
+        return choices;
+    }
 
+    @NotNull
+    static JsonObject renderSequence(SchemaNode input) {
+        JsonObject schema = new JsonObject();
+        schema.addProperty("type", "object");
+        JsonObject properties = new JsonObject();
+        schema.add("properties", properties);
+        List<String> required = new ArrayList<>();
+
+        List<? extends SchemaNode> children = input.getChildren();
+
+        for (SchemaNode child : children) {
+            if (child.isIndicator()) {
+                JsonObject subSeq = renderSequence(child);
+                subSeq.getAsJsonObject("properties")
+                        .entrySet()
+                        .forEach(entry -> properties.add(entry.getKey(), entry.getValue()));
+                if (child.getMinOccurs() > 0 && child.getIndicator() != SchemaNode.IndicatorType.choice) {
+                    Optional.ofNullable(subSeq.getAsJsonArray("required"))
+                            .ifPresent(array -> array.forEach(elem -> required.add(elem.getAsString())));
+                }
+            } else {
+                if (child.isLeaf()) {
+                    properties.add(child.getElementName(), renderLeaf(child));
+                } else {
+                    properties.add(child.getElementName(), renderElement(child));
+                }
+                if (child.getMinOccurs() > 0) {
+                    required.add(child.getElementName());
+                }
+            }
+        }
+        if (!required.isEmpty()) {
+            JsonArray array = new JsonArray();
+            required.forEach(array::add);
+            schema.add("required", array);
+        }
+        if (input.getMaxOccurs() > 1) {
+            return asArray(input, schema);
+        }
+        return schema;
+
+    }
+
+    static JsonObject asArray(SchemaNode input, JsonObject items) {
+        JsonObject array = new JsonObject();
+        array.addProperty("type", "array");
+        array.add("items", items);
+        if (input.getMinOccurs() > 0) {
+            array.addProperty("minItems", input.getMinOccurs());
+        }
+        if (input.getMaxOccurs() < UNBOUNDED_VALUE) {
+            array.addProperty("maxItems", input.getMaxOccurs());
+        }
+        return array;
+
+    }
+
+    static JsonObject renderElement(SchemaNode input) {
         if (input.isRecursive()) {
             return new JsonObject();
         }
         JsonObject schema = new JsonObject();
         schema.addProperty("type", "object");
+        String docs = input.getDocumentation();
+        if (docs != null) {
+            schema.addProperty("description", docs);
+        }
+        JsonObject properties = new JsonObject();
+        JsonArray choices = new JsonArray();
+        JsonObject arraySchema = null;
+        List<String> required = new ArrayList<>();
+
+        if (input.isSimpleType()) {   // XML element with attributes
+            JsonObject value = renderLeaf(input);
+            properties.add("content", value);
+        }
 
         List<? extends SchemaNode> children = input.getChildren();
 
-        if (input.getIndicator() == SchemaNode.IndicatorType.choice) {
-            JsonArray choices = new JsonArray();
-            schema.add("oneOf", choices);
-
-            for (SchemaNode child : children) {
-                choices.add(renderSchema(child));
-            }
-
-        } else {
-            JsonObject properties = new JsonObject();
-            schema.add("properties", properties);
-
-            if (input.isSimpleType()) {   // XML element with attributes
-                JsonObject value = renderLeaf(input);
-                properties.add("content", value);
-            }
-
-            List<String> required = new ArrayList<>();
-
-            for (SchemaNode child : children) {
-                if (child.isIndicator() && child.getIndicator() != SchemaNode.IndicatorType.choice) {
-                    JsonObject childProps = renderSchema(child);
-                    Optional.ofNullable(childProps.getAsJsonObject("properties"))
-                            .ifPresent(props -> props.entrySet()
-                                    .forEach(entry -> properties.add(entry.getKey(), entry.getValue())));
+        for (SchemaNode child : children) {
+            if (child.getIndicator() == SchemaNode.IndicatorType.choice) {
+                choices.addAll(renderOneOf(child));
+            } else if (child.isAttribute()) {
+                properties.add(child.getElementName(), renderLeaf(child));
+                if (child.getMinOccurs() > 0)
+                    required.add(child.getElementName());
+            } else {  // sequence or all
+                JsonObject seq = renderSequence(child);
+                if ("array".equals(seq.get("type").getAsString())) {
+                    arraySchema = seq;
                 } else {
-                    JsonObject prop = child.isLeaf() ? renderLeaf(child) : renderSchema(child);
-                    if (prop != null) {
-                        properties.add(child.getElementName(), prop);
-                        if (child.getMinOccurs() > 0) {
-                            required.add(child.getElementName());
-                        }
-                    }
+                    seq.getAsJsonObject("properties").entrySet()
+                            .forEach(entry -> properties.add(entry.getKey(), entry.getValue()));
+                    Optional.ofNullable(seq.getAsJsonArray("required"))
+                            .ifPresent(array -> array.forEach(elem -> required.add(elem.getAsString())));
                 }
             }
-
-            if (!required.isEmpty()) {
-                JsonArray array = new JsonArray();
-                required.forEach(array::add);
-                schema.add("required", array);
+        }
+        if (!choices.isEmpty()) {
+            if (properties.isEmpty()) {
+                schema.add("oneOf", choices);
+            } else {
+                JsonObject contents = new JsonObject();
+                contents.add("oneOf", choices);
+                contents.addProperty("type", "object");
+                properties.add("contents", contents);
             }
-            if (input.getMaxOccurs() > 1) {
-                JsonObject array = new JsonObject();
-                array.addProperty("type", "array");
-                array.add("items", schema);
-                return array;
+        }
+        if (!properties.isEmpty()) {
+            schema.add("properties", properties);
+        }
+        if (arraySchema != null) {
+             if (properties.isEmpty()) {
+                return arraySchema;
+            } else {
+                properties.add("content", arraySchema);
             }
+        }
+        if (!required.isEmpty()) {
+            JsonArray array = new JsonArray();
+            required.forEach(array::add);
+            schema.add("required", array);
+        }
+        if (input.getMaxOccurs() > 1) {
+            return asArray(input, schema);
         }
         return schema;
     }
-    
+
 }

--- a/test/com/mcsuka/xml/xsd/model/TestSchemaParser.java
+++ b/test/com/mcsuka/xml/xsd/model/TestSchemaParser.java
@@ -104,4 +104,11 @@ public class TestSchemaParser {
         GenericTools.assertEquals("Operation", actual.get(0));
     }
 
+    @Test
+    public void testChoice() throws Exception {
+        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Choice.xsd", new XsdDocumentSource());
+        SchemaNode n = model.parse("root");
+        System.out.println(n.dumpTree());
+    }
+
 }

--- a/test/com/mcsuka/xml/xsd/model/TestSchemaParser.java
+++ b/test/com/mcsuka/xml/xsd/model/TestSchemaParser.java
@@ -106,9 +106,9 @@ public class TestSchemaParser {
 
     @Test
     public void testChoice() throws Exception {
-        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Choice.xsd", new XsdDocumentSource());
-        SchemaNode n = model.parse("root");
-        System.out.println(n.dumpTree());
+        String actual = parseXsdFile("testdata/input/Choice.xsd", "root");
+        String expected = GenericTools.getResourceFile("testdata/output/Choice.txt");
+        GenericTools.assertEquals(expected, actual);
     }
 
 }

--- a/test/com/mcsuka/xml/xsd/model/TestXsd2JsonSchema.java
+++ b/test/com/mcsuka/xml/xsd/model/TestXsd2JsonSchema.java
@@ -1,0 +1,34 @@
+package com.mcsuka.xml.xsd.model;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mcsuka.xml.xsd.tools.XsdDocumentSource;
+import org.junit.jupiter.api.Test;
+
+public class TestXsd2JsonSchema {
+
+    private static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .create();
+
+    private static String json2String(JsonElement o) {
+        if (o != null) {
+            return GSON.toJson(o);
+        } else {
+            return "null";
+        }
+    }
+
+    @Test
+    public void testChoice() throws Exception {
+        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Choice.xsd", new XsdDocumentSource());
+        SchemaNode n = model.parse("root");
+        System.out.println(n.dumpTree());
+        JsonObject jschema = Xsd2JsonSchema.renderSchema(n);
+        String result = json2String(jschema);
+
+        System.out.println(result);
+    }
+}

--- a/test/com/mcsuka/xml/xsd/model/TestXsd2JsonSchema.java
+++ b/test/com/mcsuka/xml/xsd/model/TestXsd2JsonSchema.java
@@ -4,7 +4,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.mcsuka.xml.testtools.GenericTools;
 import com.mcsuka.xml.xsd.tools.XsdDocumentSource;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestXsd2JsonSchema {
@@ -13,22 +15,71 @@ public class TestXsd2JsonSchema {
             .setPrettyPrinting()
             .create();
 
-    private static String json2String(JsonElement o) {
+    private static void printJson(JsonElement o) {
         if (o != null) {
-            return GSON.toJson(o);
+            System.out.println(GSON.toJson(o));
         } else {
-            return "null";
+            System.out.println("null");
         }
     }
 
     @Test
     public void testChoice() throws Exception {
-        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Choice.xsd", new XsdDocumentSource());
+        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Choice2.xsd", new XsdDocumentSource());
         SchemaNode n = model.parse("root");
-        System.out.println(n.dumpTree());
-        JsonObject jschema = Xsd2JsonSchema.renderSchema(n);
-        String result = json2String(jschema);
+        JsonObject jschema = Xsd2JsonSchema.translateSchema(n);
+        String expected = GenericTools.getResourceFile("testdata/output/Choice2.json");
 
-        System.out.println(result);
+        Assertions.assertEquals(GSON.fromJson(expected, JsonObject.class), jschema);
+    }
+
+    @Test
+    public void testArray() throws Exception {
+        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Array2.xsd", new XsdDocumentSource());
+        SchemaNode n = model.parse("root");
+        JsonObject jschema = Xsd2JsonSchema.translateSchema(n);
+        String expected = GenericTools.getResourceFile("testdata/output/Array2.json");
+
+        Assertions.assertEquals(GSON.fromJson(expected, JsonObject.class), jschema);
+    }
+
+    @Test
+    public void testGroup() throws Exception {
+        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Group.xsd", new XsdDocumentSource());
+        SchemaNode n = model.parse("root");
+        JsonObject jschema = Xsd2JsonSchema.translateSchema(n);
+        String expected = GenericTools.getResourceFile("testdata/output/Group.json");
+
+        Assertions.assertEquals(GSON.fromJson(expected, JsonObject.class), jschema);
+    }
+
+    @Test
+    public void testComplex() throws Exception {
+        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Complex.xsd", new XsdDocumentSource());
+        SchemaNode n = model.parse("root");
+        JsonObject jschema = Xsd2JsonSchema.translateSchema(n);
+        String expected = GenericTools.getResourceFile("testdata/output/Complex.json");
+
+        Assertions.assertEquals(GSON.fromJson(expected, JsonObject.class), jschema);
+    }
+
+    @Test
+    public void testSimple5() throws Exception {
+        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Simple.xsd", new XsdDocumentSource());
+        SchemaNode n = model.parse("root5");
+        JsonObject jschema = Xsd2JsonSchema.translateSchema(n);
+        String expected = GenericTools.getResourceFile("testdata/output/Simple5.json");
+
+        Assertions.assertEquals(GSON.fromJson(expected, JsonObject.class), jschema);
+    }
+
+    @Test
+    public void testSimple3() throws Exception {
+        SchemaParser model = SchemaParserFactory.newSchemaParser("testdata/input/Simple.xsd", new XsdDocumentSource());
+        SchemaNode n = model.parse("root3");
+        JsonObject jschema = Xsd2JsonSchema.translateSchema(n);
+        String expected = GenericTools.getResourceFile("testdata/output/Simple3.json");
+
+        Assertions.assertEquals(GSON.fromJson(expected, JsonObject.class), jschema);
     }
 }

--- a/testdata/input/Choice.xsd
+++ b/testdata/input/Choice.xsd
@@ -5,7 +5,7 @@
             <xs:documentation>Comment describing your root element</xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:sequence maxOccurs="unbounded">
+            <xs:sequence>
                 <xs:choice>
                     <xs:element name="aEnum">
                         <xs:simpleType>

--- a/testdata/input/Choice.xsd
+++ b/testdata/input/Choice.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://dummy" targetNamespace="http://dummy" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:element name="root">
+        <xs:annotation>
+            <xs:documentation>Comment describing your root element</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence maxOccurs="unbounded">
+                <xs:choice>
+                    <xs:element name="aEnum">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="X"/>
+                                <xs:enumeration value="Y"/>
+                                <xs:enumeration value="Z"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="aRegex">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="[1-5][0-9]{3}"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                </xs:choice>
+                <xs:choice>
+                    <xs:element name="b1" type="xs:integer" maxOccurs="9" default="1"/>
+                    <xs:element name="b2" type="xs:integer" maxOccurs="9" fixed="99"/>
+                </xs:choice>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/testdata/input/Choice2.xsd
+++ b/testdata/input/Choice2.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://dummy.com" targetNamespace="http://dummy.com" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:element name="root">
+        <xs:annotation>
+            <xs:documentation>Comment describing your root element</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:choice>
+                <xs:sequence>
+                    <xs:element name="aEnum">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="X"/>
+                                <xs:enumeration value="Y"/>
+                                <xs:enumeration value="Z"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="aRegex">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="[1-5][0-9]{3}"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:sequence>
+                    <xs:element name="b1" type="xs:integer" maxOccurs="9" default="1"/>
+                    <xs:element name="b2" type="xs:integer" maxOccurs="9" fixed="99"/>
+                </xs:sequence>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/testdata/output/Array2.json
+++ b/testdata/output/Array2.json
@@ -1,0 +1,30 @@
+{
+  "type": "object",
+  "description": "Comment describing your root element",
+  "properties": {
+    "x": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ]
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "x"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dummy?root"
+}

--- a/testdata/output/Choice.txt
+++ b/testdata/output/Choice.txt
@@ -1,0 +1,8 @@
+XmlSchemaNode {/root, COMPLEX, 1..1, NS:http://dummy, QUALIFIED, "null", "Comment describing your root element"}
+XmlSchemaNode {/root/, sequence, 1..2147483647}
+XmlSchemaNode {/root/, choice, 1..1}
+XmlSchemaNode {/root/aEnum, STRING, 1..1, NS:http://dummy, QUALIFIED, "enumeration: 'X|Y|Z'", "null"}
+XmlSchemaNode {/root/aRegex, STRING, 1..1, NS:http://dummy, QUALIFIED, "pattern: '[1-5][0-9]{3}'", "null"}
+XmlSchemaNode {/root/, choice, 1..1}
+XmlSchemaNode {/root/b1, LONG, 1..9, NS:http://dummy, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root/b2, LONG, 1..9, NS:http://dummy, QUALIFIED, "null", "null"}

--- a/testdata/output/Choice.txt
+++ b/testdata/output/Choice.txt
@@ -1,5 +1,5 @@
 XmlSchemaNode {/root, COMPLEX, 1..1, NS:http://dummy, QUALIFIED, "null", "Comment describing your root element"}
-XmlSchemaNode {/root/, sequence, 1..2147483647}
+XmlSchemaNode {/root/, sequence, 1..1}
 XmlSchemaNode {/root/, choice, 1..1}
 XmlSchemaNode {/root/aEnum, STRING, 1..1, NS:http://dummy, QUALIFIED, "enumeration: 'X|Y|Z'", "null"}
 XmlSchemaNode {/root/aRegex, STRING, 1..1, NS:http://dummy, QUALIFIED, "pattern: '[1-5][0-9]{3}'", "null"}

--- a/testdata/output/Choice2.json
+++ b/testdata/output/Choice2.json
@@ -1,0 +1,56 @@
+{
+  "type": "object",
+  "description": "Comment describing your root element",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "aEnum": {
+          "type": "string",
+          "enum": [
+            "X",
+            "Y",
+            "Z"
+          ]
+        },
+        "aRegex": {
+          "type": "string",
+          "pattern": "[1-5][0-9]{3}"
+        }
+      },
+      "required": [
+        "aEnum",
+        "aRegex"
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "b1": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "default": "1"
+          },
+          "minItems": 1,
+          "maxItems": 9
+        },
+        "b2": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "const": "99"
+          },
+          "minItems": 1,
+          "maxItems": 9
+        }
+      },
+      "required": [
+        "b1",
+        "b2"
+      ]
+    }
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dummy.com?root"
+}

--- a/testdata/output/Complex.json
+++ b/testdata/output/Complex.json
@@ -1,0 +1,90 @@
+{
+  "type": "object",
+  "properties": {
+    "header": {
+      "type": "object",
+      "description": "Message Header",
+      "properties": {
+        "messageID": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userID": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10
+        }
+      },
+      "required": [
+        "messageID",
+        "timestamp"
+      ]
+    },
+    "body": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "type": "object",
+          "properties": {
+            "resultCode": {
+              "type": "integer"
+            },
+            "resultText": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "resultCode",
+            "resultText"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "description": "Some data",
+          "properties": {
+            "customerType": {
+              "type": "string"
+            },
+            "customerId": {
+              "type": "integer"
+            },
+            "products": {
+              "type": "object",
+              "properties": {
+                "productId": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                }
+              },
+              "required": [
+                "productId"
+              ]
+            }
+          },
+          "required": [
+            "customerType",
+            "customerId"
+          ]
+        }
+      },
+      "required": [
+        "result"
+      ]
+    }
+  },
+  "required": [
+    "header",
+    "body"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dummy.org/Complex.xsd?root"
+}

--- a/testdata/output/Complex.txt
+++ b/testdata/output/Complex.txt
@@ -1,22 +1,22 @@
-SimpleXSDModelNode {/root, COMPLEX, 1..1, TYPE:type_Skeleton, NS:http://dummy.org/Complex.xsd, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/, sequence, 1..1}
-SimpleXSDModelNode {/root/header, COMPLEX, 1..1, TYPE:type_Header, NS:http://dummy.org/types/Skeleton.xsd, UNQUALIFIED, "null", "Message Header"}
-SimpleXSDModelNode {/root/header/, sequence, 1..1}
-SimpleXSDModelNode {/root/header/messageID, STRING, 1..1, NS:http://dummy.org/types/Header.xsd, UNQUALIFIED, "null", "Unique ID for this message"}
-SimpleXSDModelNode {/root/header/timestamp, DATETIME, 1..1, NS:http://dummy.org/types/Header.xsd, UNQUALIFIED, "null", "The timestamp of each message birth"}
-SimpleXSDModelNode {/root/header/userID, STRING, 0..1, NS:http://dummy.org/types/Header.xsd, UNQUALIFIED, "null", "A valid user"}
-SimpleXSDModelNode {/root/header/priority, INTEGER, 0..1, TYPE:type_Priority, NS:http://dummy.org/types/Header.xsd, UNQUALIFIED, "maxInclusive:10, minInclusive:0", "Message priority"}
-SimpleXSDModelNode {/root/, sequence, 1..1}
-SimpleXSDModelNode {/root/body, COMPLEX, 1..1, TYPE:type_Body, NS:http://dummy.org/Complex.xsd, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/body/, sequence, 1..1}
-SimpleXSDModelNode {/root/body/result, COMPLEX, 1..1, TYPE:type_Result, NS:http://dummy.org/Complex.xsd, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/body/result/, sequence, 1..1}
-SimpleXSDModelNode {/root/body/result/resultCode, INTEGER, 1..1, NS:http://dummy.org/types/Result.xsd, UNQUALIFIED, "enumeration: '0' '10' '20'", "null"}
-SimpleXSDModelNode {/root/body/result/resultText, STRING, 1..1, NS:http://dummy.org/types/Result.xsd, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/body/data, COMPLEX, 0..1, TYPE:type_Data, NS:http://dummy.org/Complex.xsd, UNQUALIFIED, "null", "Some data"}
-SimpleXSDModelNode {/root/body/data/, sequence, 1..1}
-SimpleXSDModelNode {/root/body/data/customerType, STRING, 1..1, NS:http://dummy.org/types/Data.xsd, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/body/data/customerId, INTEGER, 1..1, NS:http://dummy.org/types/Data.xsd, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/body/data/products, COMPLEX, 0..1, NS:http://dummy.org/types/Data.xsd, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/body/data/products/, sequence, 1..1}
-SimpleXSDModelNode {/root/body/data/products/productId, STRING, 1..2147483647, NS:http://dummy.org/types/Data.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root, COMPLEX, 1..1, TYPE:type_Skeleton, NS:http://dummy.org/Complex.xsd, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root/, sequence, 1..1}
+XmlSchemaNode {/root/header, COMPLEX, 1..1, TYPE:type_Header, NS:http://dummy.org/types/Skeleton.xsd, UNQUALIFIED, "null", "Message Header"}
+XmlSchemaNode {/root/header/, sequence, 1..1}
+XmlSchemaNode {/root/header/messageID, STRING, 1..1, NS:http://dummy.org/types/Header.xsd, UNQUALIFIED, "null", "Unique ID for this message"}
+XmlSchemaNode {/root/header/timestamp, DATETIME, 1..1, NS:http://dummy.org/types/Header.xsd, UNQUALIFIED, "null", "The timestamp of each message birth"}
+XmlSchemaNode {/root/header/userID, STRING, 0..1, NS:http://dummy.org/types/Header.xsd, UNQUALIFIED, "null", "A valid user"}
+XmlSchemaNode {/root/header/priority, INTEGER, 0..1, TYPE:type_Priority, NS:http://dummy.org/types/Header.xsd, UNQUALIFIED, "maxInclusive: '10'; minInclusive: '0'", "Message priority"}
+XmlSchemaNode {/root/, sequence, 1..1}
+XmlSchemaNode {/root/body, COMPLEX, 1..1, TYPE:type_Body, NS:http://dummy.org/Complex.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root/body/, sequence, 1..1}
+XmlSchemaNode {/root/body/result, COMPLEX, 1..1, TYPE:type_Result, NS:http://dummy.org/Complex.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root/body/result/, sequence, 1..1}
+XmlSchemaNode {/root/body/result/resultCode, INTEGER, 1..1, NS:http://dummy.org/types/Result.xsd, UNQUALIFIED, "enumeration: '0|10|20'", "null"}
+XmlSchemaNode {/root/body/result/resultText, STRING, 1..1, NS:http://dummy.org/types/Result.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root/body/data, COMPLEX, 0..1, TYPE:type_Data, NS:http://dummy.org/Complex.xsd, UNQUALIFIED, "null", "Some data"}
+XmlSchemaNode {/root/body/data/, sequence, 1..1}
+XmlSchemaNode {/root/body/data/customerType, STRING, 1..1, NS:http://dummy.org/types/Data.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root/body/data/customerId, INTEGER, 1..1, NS:http://dummy.org/types/Data.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root/body/data/products, COMPLEX, 0..1, NS:http://dummy.org/types/Data.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root/body/data/products/, sequence, 1..1}
+XmlSchemaNode {/root/body/data/products/productId, STRING, 1..2147483647, NS:http://dummy.org/types/Data.xsd, UNQUALIFIED, "null", "null"}

--- a/testdata/output/Group.json
+++ b/testdata/output/Group.json
@@ -1,0 +1,29 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "pre": {
+        "type": "string"
+      },
+      "a": {
+        "type": "string"
+      },
+      "b": {
+        "type": "string"
+      },
+      "post": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "pre",
+      "a",
+      "b",
+      "post"
+    ]
+  },
+  "minItems": 1,
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dummy?root"
+}

--- a/testdata/output/Group.txt
+++ b/testdata/output/Group.txt
@@ -1,7 +1,7 @@
-SimpleXSDModelNode {/root, COMPLEX, 1..1, NS:http://dummy, QUALIFIED, "null", "Comment describing your root element"}
-SimpleXSDModelNode {/root/, sequence, 1..2147483647}
-SimpleXSDModelNode {/root/pre, STRING, 1..1, NS:http://dummy, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/, sequence, 1..1}
-SimpleXSDModelNode {/root/a, STRING, 1..1, NS:http://dummy, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/b, STRING, 1..1, NS:http://dummy, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root/post, STRING, 1..1, NS:http://dummy, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root, COMPLEX, 1..1, NS:http://dummy, QUALIFIED, "null", "Comment describing your root element"}
+XmlSchemaNode {/root/, sequence, 1..2147483647}
+XmlSchemaNode {/root/pre, STRING, 1..1, NS:http://dummy, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root/, sequence, 1..1}
+XmlSchemaNode {/root/a, STRING, 1..1, NS:http://dummy, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root/b, STRING, 1..1, NS:http://dummy, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root/post, STRING, 1..1, NS:http://dummy, QUALIFIED, "null", "null"}

--- a/testdata/output/OneServiceWSDL.txt
+++ b/testdata/output/OneServiceWSDL.txt
@@ -1,24 +1,24 @@
-SimpleXSDModelNode {/RequestMessage, COMPLEX, 1..1, TYPE:type_MessageSkeleton_2, NS:http://dummy.net/RequestMessage.xsd, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/RequestMessage/, sequence, 1..1}
-SimpleXSDModelNode {/RequestMessage/header, COMPLEX, 1..1, TYPE:type_MessageHeader, NS:http://dummy.net/types/type_MessageSkeleton_2.xsd, UNQUALIFIED, "null", "Message Header"}
-SimpleXSDModelNode {/RequestMessage/header/, sequence, 1..1}
-SimpleXSDModelNode {/RequestMessage/header/messageID, STRING, 1..1, NS:http://dummy.net/types/type_MessageHeader.xsd, UNQUALIFIED, "null", "Unique ID"}
-SimpleXSDModelNode {/RequestMessage/header/timestamp, DATETIME, 1..1, TYPE:type_DateTimeWithTimezone, NS:http://dummy.net/types/type_MessageHeader.xsd, UNQUALIFIED, "pattern: '.+T.+(Z|[+\-].+)'", "The timestamp of each message birth"}
-SimpleXSDModelNode {/RequestMessage/header/userID, STRING, 0..1, NS:http://dummy.net/types/type_MessageHeader.xsd, UNQUALIFIED, "null", "Unique user identifier"}
-SimpleXSDModelNode {/RequestMessage/header/priority, INTEGER, 0..1, TYPE:type_Priority, NS:http://dummy.net/types/type_MessageHeader.xsd, UNQUALIFIED, "maxInclusive:10, minInclusive:0", "Message priority (not used at the moment)"}
-SimpleXSDModelNode {/RequestMessage/, sequence, 1..1}
-SimpleXSDModelNode {/RequestMessage/body, COMPLEX, 1..1, TYPE:type_Body, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/RequestMessage/body/, sequence, 1..1}
-SimpleXSDModelNode {/RequestMessage/body/contract, COMPLEX, 1..1, TYPE:type_Contract, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "Base abstract Contract Class"}
-SimpleXSDModelNode {/RequestMessage/body/contract/, sequence, 1..1}
-SimpleXSDModelNode {/RequestMessage/body/contract/contractID, STRING, 1..1, TYPE:type_ContractID, NS:http://dummy.net/types/type_ContractReferenceAndCustomerCode.xsd, UNQUALIFIED, "pattern: '\d{10,19}'", "null"}
-SimpleXSDModelNode {/RequestMessage/body/contract/customerCode, STRING, 1..1, TYPE:type_CustomerCode, NS:http://dummy.net/types/type_ContractReferenceAndCustomerCode.xsd, UNQUALIFIED, "maxLength:24, pattern: '[0-9\.]+'", "null"}
-SimpleXSDModelNode {/RequestMessage/body/cards, COMPLEX, 0..1, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "Related contracts"}
-SimpleXSDModelNode {/RequestMessage/body/cards/, sequence, 1..1}
-SimpleXSDModelNode {/RequestMessage/body/cards/card, COMPLEX, 1..2147483647, TYPE:type_Contract, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "Identifies the contract"}
-SimpleXSDModelNode {/RequestMessage/body/cards/card/, sequence, 1..1}
-SimpleXSDModelNode {/RequestMessage/body/cards/card/contractID, STRING, 1..1, TYPE:type_ContractID, NS:http://dummy.net/types/type_ContractReference.xsd, UNQUALIFIED, "pattern: '\d{10,19}'", "null"}
-SimpleXSDModelNode {/RequestMessage/body/reason, COMPLEX, 1..1, TYPE:type_Reason, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/RequestMessage/body/reason/, sequence, 1..1}
-SimpleXSDModelNode {/RequestMessage/body/reason/code, STRING, 1..1, NS:http://dummy.net/types/type_Reason.xsd, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/RequestMessage/body/reason/description, STRING, 1..1, NS:http://dummy.net/types/type_Reason.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/RequestMessage, COMPLEX, 1..1, TYPE:type_MessageSkeleton_2, NS:http://dummy.net/RequestMessage.xsd, QUALIFIED, "null", "null"}
+XmlSchemaNode {/RequestMessage/, sequence, 1..1}
+XmlSchemaNode {/RequestMessage/header, COMPLEX, 1..1, TYPE:type_MessageHeader, NS:http://dummy.net/types/type_MessageSkeleton_2.xsd, UNQUALIFIED, "null", "Message Header"}
+XmlSchemaNode {/RequestMessage/header/, sequence, 1..1}
+XmlSchemaNode {/RequestMessage/header/messageID, STRING, 1..1, NS:http://dummy.net/types/type_MessageHeader.xsd, UNQUALIFIED, "null", "Unique ID"}
+XmlSchemaNode {/RequestMessage/header/timestamp, DATETIME, 1..1, TYPE:type_DateTimeWithTimezone, NS:http://dummy.net/types/type_MessageHeader.xsd, UNQUALIFIED, "pattern: '.+T.+(Z|[+\-].+)'", "The timestamp of each message birth"}
+XmlSchemaNode {/RequestMessage/header/userID, STRING, 0..1, NS:http://dummy.net/types/type_MessageHeader.xsd, UNQUALIFIED, "null", "Unique user identifier"}
+XmlSchemaNode {/RequestMessage/header/priority, INTEGER, 0..1, TYPE:type_Priority, NS:http://dummy.net/types/type_MessageHeader.xsd, UNQUALIFIED, "maxInclusive: '10'; minInclusive: '0'", "Message priority (not used at the moment)"}
+XmlSchemaNode {/RequestMessage/, sequence, 1..1}
+XmlSchemaNode {/RequestMessage/body, COMPLEX, 1..1, TYPE:type_Body, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/RequestMessage/body/, sequence, 1..1}
+XmlSchemaNode {/RequestMessage/body/contract, COMPLEX, 1..1, TYPE:type_Contract, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "Base abstract Contract Class"}
+XmlSchemaNode {/RequestMessage/body/contract/, sequence, 1..1}
+XmlSchemaNode {/RequestMessage/body/contract/contractID, STRING, 1..1, TYPE:type_ContractID, NS:http://dummy.net/types/type_ContractReferenceAndCustomerCode.xsd, UNQUALIFIED, "pattern: '\d{10,19}'", "null"}
+XmlSchemaNode {/RequestMessage/body/contract/customerCode, STRING, 1..1, TYPE:type_CustomerCode, NS:http://dummy.net/types/type_ContractReferenceAndCustomerCode.xsd, UNQUALIFIED, "maxLength: '24'; pattern: '[0-9\.]+'", "null"}
+XmlSchemaNode {/RequestMessage/body/cards, COMPLEX, 0..1, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "Related contracts"}
+XmlSchemaNode {/RequestMessage/body/cards/, sequence, 1..1}
+XmlSchemaNode {/RequestMessage/body/cards/card, COMPLEX, 1..2147483647, TYPE:type_Contract, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "Identifies the contract"}
+XmlSchemaNode {/RequestMessage/body/cards/card/, sequence, 1..1}
+XmlSchemaNode {/RequestMessage/body/cards/card/contractID, STRING, 1..1, TYPE:type_ContractID, NS:http://dummy.net/types/type_ContractReference.xsd, UNQUALIFIED, "pattern: '\d{10,19}'", "null"}
+XmlSchemaNode {/RequestMessage/body/reason, COMPLEX, 1..1, TYPE:type_Reason, NS:http://dummy.net/RequestMessage.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/RequestMessage/body/reason/, sequence, 1..1}
+XmlSchemaNode {/RequestMessage/body/reason/code, STRING, 1..1, NS:http://dummy.net/types/type_Reason.xsd, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/RequestMessage/body/reason/description, STRING, 1..1, NS:http://dummy.net/types/type_Reason.xsd, UNQUALIFIED, "null", "null"}

--- a/testdata/output/Restriction.txt
+++ b/testdata/output/Restriction.txt
@@ -1,4 +1,4 @@
-SimpleXSDModelNode {/root, COMPLEX, 1..1, NS:http://dummy, QUALIFIED, "null", "Comment describing your root element"}
-SimpleXSDModelNode {/root/, sequence, 1..2147483647}
-SimpleXSDModelNode {/root/a, STRING, 1..1, NS:http://dummy, QUALIFIED, "enumeration: 'X' 'Y' 'Z'", "null"}
-SimpleXSDModelNode {/root/b, STRING, 1..1, NS:http://dummy, QUALIFIED, "pattern: '[1-5][0-9]{3}'", "null"}
+XmlSchemaNode {/root, COMPLEX, 1..1, NS:http://dummy, QUALIFIED, "null", "Comment describing your root element"}
+XmlSchemaNode {/root/, sequence, 1..2147483647}
+XmlSchemaNode {/root/a, STRING, 1..1, NS:http://dummy, QUALIFIED, "enumeration: 'X|Y|Z'", "null"}
+XmlSchemaNode {/root/b, STRING, 1..1, NS:http://dummy, QUALIFIED, "pattern: '[1-5][0-9]{3}'", "null"}

--- a/testdata/output/Simple3.json
+++ b/testdata/output/Simple3.json
@@ -1,0 +1,73 @@
+{
+  "type": "object",
+  "properties": {
+    "address": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string"
+          },
+          "houseNumber": {
+            "type": "integer"
+          },
+          "postCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "municipality": {
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "*": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "info": {
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "*": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "maxItems": 10
+              }
+            },
+            "required": [
+              "*"
+            ]
+          }
+        },
+        "required": [
+          "street",
+          "houseNumber",
+          "postCode",
+          "city",
+          "municipality",
+          "info"
+        ]
+      },
+      "minItems": 1,
+      "maxItems": 2
+    }
+  },
+  "required": [
+    "address"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dummy.org/1231312?root3"
+}

--- a/testdata/output/Simple5.json
+++ b/testdata/output/Simple5.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "properties": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "postCode": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "street": {
+          "type": "string"
+        },
+        "houseNumber": {
+          "type": "object",
+          "properties": {
+            "content": {
+              "type": "integer",
+              "default": "3"
+            },
+            "*": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "houseNumber"
+      ]
+    }
+  },
+  "required": [
+    "address"
+  ],
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dummy.org/1231312?root5"
+}

--- a/testdata/output/SimpleRoot1.txt
+++ b/testdata/output/SimpleRoot1.txt
@@ -1,13 +1,13 @@
-SimpleXSDModelNode {/root1, COMPLEX, 1..1, TYPE:type_Body_1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root1/, sequence, 1..1}
-SimpleXSDModelNode {/root1/address, COMPLEX, 0..1, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root1/address/, sequence, 1..1}
-SimpleXSDModelNode {/root1/address/street, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root1/address/houseNumber, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root1/address/postCode, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root1/address/city, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root1/address/municipality, BOOLEAN, 1..1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root1/address/municipality/x, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, ATTR, "fixed value: x", "null"}
-SimpleXSDModelNode {/root1/address/address, COMPLEX, 0..2147483647, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root1/address/, sequence, 0..1}
-SimpleXSDModelNode {/root1/address/addres, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root1, COMPLEX, 1..1, TYPE:type_Body_1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root1/, sequence, 1..1}
+XmlSchemaNode {/root1/address, COMPLEX, 0..1, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root1/address/, sequence, 1..1}
+XmlSchemaNode {/root1/address/street, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root1/address/houseNumber, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root1/address/postCode, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root1/address/city, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root1/address/municipality, BOOLEAN, 1..1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root1/address/municipality/x, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, ATTR, "null", "null"}
+XmlSchemaNode {/root1/address/address, COMPLEX, 0..2147483647, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root1/address/, sequence, 0..1}
+XmlSchemaNode {/root1/address/addres, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}

--- a/testdata/output/SimpleRoot2.txt
+++ b/testdata/output/SimpleRoot2.txt
@@ -1,11 +1,11 @@
-SimpleXSDModelNode {/root2, COMPLEX, 1..1, TYPE:type_Body_2, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root2/, sequence, 1..1}
-SimpleXSDModelNode {/root2/address, COMPLEX, 1..1, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root2/address/, sequence, 1..1}
-SimpleXSDModelNode {/root2/address/street, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root2/address/houseNumber, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root2/address/postCode, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root2/address/city, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root2/address/municipality, BOOLEAN, 1..1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root2/address/municipality/x, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, ATTR, "fixed value: x", "null"}
-SimpleXSDModelNode {/root2/address/address, COMPLEX, 0..2147483647, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root2, COMPLEX, 1..1, TYPE:type_Body_2, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root2/, sequence, 1..1}
+XmlSchemaNode {/root2/address, COMPLEX, 1..1, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root2/address/, sequence, 1..1}
+XmlSchemaNode {/root2/address/street, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root2/address/houseNumber, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root2/address/postCode, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root2/address/city, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root2/address/municipality, BOOLEAN, 1..1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root2/address/municipality/x, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, ATTR, "null", "null"}
+XmlSchemaNode {/root2/address/address, COMPLEX, 0..2147483647, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}

--- a/testdata/output/SimpleRoot2Address.txt
+++ b/testdata/output/SimpleRoot2Address.txt
@@ -1,9 +1,9 @@
-SimpleXSDModelNode {/address, COMPLEX, 1..1, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/address/, sequence, 1..1}
-SimpleXSDModelNode {/address/street, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/address/houseNumber, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/address/postCode, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/address/city, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/address/municipality, BOOLEAN, 1..1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/address/municipality/x, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, ATTR, "fixed value: x", "null"}
-SimpleXSDModelNode {/address/address, COMPLEX, 0..2147483647, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/address, COMPLEX, 1..1, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/address/, sequence, 1..1}
+XmlSchemaNode {/address/street, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/address/houseNumber, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/address/postCode, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/address/city, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/address/municipality, BOOLEAN, 1..1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
+XmlSchemaNode {/address/municipality/x, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, ATTR, "null", "null"}
+XmlSchemaNode {/address/address, COMPLEX, 0..2147483647, TYPE:type_Address, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}

--- a/testdata/output/SimpleRoot3.txt
+++ b/testdata/output/SimpleRoot3.txt
@@ -1,13 +1,13 @@
-SimpleXSDModelNode {/root3, COMPLEX, 1..1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root3/, sequence, 1..1}
-SimpleXSDModelNode {/root3/address, COMPLEX, 1..2, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root3/address/, sequence, 1..1}
-SimpleXSDModelNode {/root3/address/street, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root3/address/houseNumber, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root3/address/postCode, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root3/address/city, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root3/address/municipality, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root3/address/municipality/*, ANY, 0..2147483647, NS:http://dummy.org/1231312, UNQUALIFIED, ATTR, ANY, "null", "null"}
-SimpleXSDModelNode {/root3/address/info, MIXED, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
-SimpleXSDModelNode {/root3/address/info/, sequence, 1..1}
-SimpleXSDModelNode {/root3/address/info/*, ANY, 1..10, NS:http://dummy.org/1231312, UNQUALIFIED, ANY, "null", "null"}
+XmlSchemaNode {/root3, COMPLEX, 1..1, NS:http://dummy.org/1231312, QUALIFIED, "null", "null"}
+XmlSchemaNode {/root3/, sequence, 1..1}
+XmlSchemaNode {/root3/address, COMPLEX, 1..2, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root3/address/, sequence, 1..1}
+XmlSchemaNode {/root3/address/street, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root3/address/houseNumber, INTEGER, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root3/address/postCode, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root3/address/city, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root3/address/municipality, STRING, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root3/address/municipality/*, ANY, 0..2147483647, NS:http://dummy.org/1231312, UNQUALIFIED, ATTR, ANY, "null", "null"}
+XmlSchemaNode {/root3/address/info, MIXED, 1..1, NS:http://dummy.org/1231312, UNQUALIFIED, "null", "null"}
+XmlSchemaNode {/root3/address/info/, sequence, 1..1}
+XmlSchemaNode {/root3/address/info/*, ANY, 1..10, NS:http://dummy.org/1231312, UNQUALIFIED, ANY, "null", "null"}


### PR DESCRIPTION
Best-effort function to translate an XML Schema element (SchemaNode) to a JSON Schema.
Not all XML Schema constructions can be translated into JSON Schema, e.g. JSON does not ensure sequence,
cannot have repeating groups of elements or a sequence of choice (oneOf) groups.